### PR TITLE
Fix map attribution typo

### DIFF
--- a/src/app/tab1/tab1.page.ts
+++ b/src/app/tab1/tab1.page.ts
@@ -115,7 +115,7 @@ export class Tab1Page {
   loadmap() {
     console.log("loadmap called");
     leaflet.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attributions: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+      attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
       maxZoom: 18
     }).addTo(this.map);
 


### PR DESCRIPTION
There is a typo in the map attribution.

May be some extra data could be added about the markers data, but I'm not sure where is that data from.